### PR TITLE
Loosely check rewrite rules check

### DIFF
--- a/lib/admin/cpt/cpt.announcements.php
+++ b/lib/admin/cpt/cpt.announcements.php
@@ -95,7 +95,7 @@ register_post_type( 'te_announcements', $timeline_express_args );
 
 /* Flush the re-write rules/permalinks - prevents 404 on initial plugin activation */
 $set = get_option( 'post_type_rules_flushed_te-announcements', false );
-if ( true !== $set ) {
+if ( ! $set ) {
 	flush_rewrite_rules( false );
-	update_option( 'post_type_rules_flushed_te-announcements', true );
+	update_option( 'post_type_rules_flushed_te-announcements', 1 );
 }


### PR DESCRIPTION
Attempting to store a boolean in the database will result in an actual stored value of "1" or "0", at least for options storage, for which the value schema is `longtext`.
The result of checking `true !== $set` will be that rewrite rules are flushed every time this file is loaded (which is every page load).
This wreaks havoc on some systems, esp those with unique database/caching mechanisms in place.

This patch should also be applied to the premium version of this plugin.