### PR TITLE
Allow to disable post link

### DIFF
--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -479,7 +479,7 @@ function does_timeline_express_init_class_exist() {
  *
  * @return string           The HTML markup to return
  */
-function timeline_express_get_announcement_icon_markup( $post_id ) {
+function timeline_express_get_announcement_icon_markup( $post_id , $add_link = true ) {
 
 	$timeline_express_options = timeline_express_get_options();
 
@@ -499,11 +499,12 @@ function timeline_express_get_announcement_icon_markup( $post_id ) {
 
 		$icon_container_class = '';
 
-		?>
+		if ($add_link){ ?>
 
 		<a class="cd-timeline-icon-link" href="<?php echo esc_attr( apply_filters( 'timeline_express_announcement_permalink', get_the_permalink( $post_id ), $post_id ) ); ?>">
 
-	<?php } ?>
+		<?php }
+		} ?>
 
 		<div class="cd-timeline-img cd-picture<?php echo esc_attr( $icon_container_class ); ?>" style="background:<?php echo esc_attr( timeline_express_get_announcement_icon_color( $post_id ) ); ?>;">
 


### PR DESCRIPTION
Hi,

First, i'd like to say that your plugin helped me to achieave a simple history in a website
I just want the timeline effect without a link to the post (i dont need that ppl clik on the icons), so i added a small change to disable the link.

To do so, you need to add 'false' option the timeline-express-container.php template
By default, it will add the link

`echo wp_kses_post( timeline_express_get_announcement_icon_markup( $post->ID ,false) );`

I hope that this small contribution will be usefull :)
