### PR TITLE
i18n: replece context functions with translators comment

### DIFF
--- a/lib/admin/cpt/timeline-express-admin-columns.php
+++ b/lib/admin/cpt/timeline-express-admin-columns.php
@@ -46,7 +46,11 @@ function add_new_timeline_express_columns( $timeline_express_announcement_column
 
 	$timeline_express_announcement_columns['cb'] = '<input type="checkbox" />';
 
-	$timeline_express_announcement_columns['title'] = sprintf( esc_html_x( '%s Name', 'Announcement singular name eg: Announcement Name', 'timeline-express' ), $timeline_express_singular_name );
+	$timeline_express_announcement_columns['title'] = sprintf(
+		/* translator: %s: Announcement singular name eg: Announcement Name */
+		esc_html__( '%s Name', 'timeline-express' ),
+		$timeline_express_singular_name
+	);
 
 	$timeline_express_announcement_columns['color'] = esc_html__( 'Color', 'timeline-express' );
 
@@ -57,11 +61,19 @@ function add_new_timeline_express_columns( $timeline_express_announcement_column
 
 	}
 
-	$timeline_express_announcement_columns['announcement_date'] = sprintf( esc_html_x( '%s Date', 'Announcement singular name eg: Announcement Date', 'timeline-express' ), $timeline_express_singular_name );
+	$timeline_express_announcement_columns['announcement_date'] = sprintf(
+		/* translator: %s: Announcement singular name eg: Announcement Date */
+		esc_html__( '%s Date', 'timeline-express' ),
+		$timeline_express_singular_name
+	);
 
 	$timeline_express_announcement_columns['image'] = esc_html__( 'Image', 'timeline-express' );
 
-	$timeline_express_announcement_columns['past_announcement'] = sprintf( esc_html_x( '%s Past?', 'Announcement singular name eg: Announcement Past?', 'timeline-express' ), $timeline_express_singular_name );
+	$timeline_express_announcement_columns['past_announcement'] = sprintf(
+		/* translator: %s: Announcement singular name eg: Announcement Past? */
+		esc_html__( '%s Past?', 'timeline-express' ),
+		$timeline_express_singular_name
+	);
 
 	$timeline_express_announcement_columns['date'] = esc_html__( 'Published Date', 'timeline-express' );
 

--- a/lib/admin/cpt/timeline-express-admin-columns.php
+++ b/lib/admin/cpt/timeline-express-admin-columns.php
@@ -47,7 +47,7 @@ function add_new_timeline_express_columns( $timeline_express_announcement_column
 	$timeline_express_announcement_columns['cb'] = '<input type="checkbox" />';
 
 	$timeline_express_announcement_columns['title'] = sprintf(
-		/* translator: %s: Announcement singular name eg: Announcement Name */
+		/* translators: %s: Announcement singular name eg: Announcement Name */
 		esc_html__( '%s Name', 'timeline-express' ),
 		$timeline_express_singular_name
 	);
@@ -62,7 +62,7 @@ function add_new_timeline_express_columns( $timeline_express_announcement_column
 	}
 
 	$timeline_express_announcement_columns['announcement_date'] = sprintf(
-		/* translator: %s: Announcement singular name eg: Announcement Date */
+		/* translators: %s: Announcement singular name eg: Announcement Date */
 		esc_html__( '%s Date', 'timeline-express' ),
 		$timeline_express_singular_name
 	);
@@ -70,7 +70,7 @@ function add_new_timeline_express_columns( $timeline_express_announcement_column
 	$timeline_express_announcement_columns['image'] = esc_html__( 'Image', 'timeline-express' );
 
 	$timeline_express_announcement_columns['past_announcement'] = sprintf(
-		/* translator: %s: Announcement singular name eg: Announcement Past? */
+		/* translators: %s: Announcement singular name eg: Announcement Past? */
 		esc_html__( '%s Past?', 'timeline-express' ),
 		$timeline_express_singular_name
 	);

--- a/lib/admin/pages/page.addons.php
+++ b/lib/admin/pages/page.addons.php
@@ -95,7 +95,7 @@ shuffle( $addon_array );
 array_unshift( $addon_array, [
 	'name'          => esc_html__( 'Timeline Express Product Bundle', 'timeline-express' ),
 	'description'   => sprintf(
-		 /* translator: %s: Integer value for the number of add-ons in the add-on list. (eg: 6). */
+		 /* translators: %s: Integer value for the number of add-ons in the add-on list. (eg: 6). */
 		esc_html__( "Get any and all %s of the Timeline Express add-ons, for one low price! Select a 5 or 10 site license, and receive all current and future add-ons for Timeline Express along with updates and priority product support. An amazing deal, don't miss it!", 'timeline-express' ),
 		count( $addon_array )
 	),

--- a/lib/admin/pages/page.addons.php
+++ b/lib/admin/pages/page.addons.php
@@ -94,7 +94,11 @@ shuffle( $addon_array );
 
 array_unshift( $addon_array, [
 	'name'          => esc_html__( 'Timeline Express Product Bundle', 'timeline-express' ),
-	'description'   => sprintf( esc_html_x( "Get any and all %s of the Timeline Express add-ons, for one low price! Select a 5 or 10 site license, and receive all current and future add-ons for Timeline Express along with updates and priority product support. An amazing deal, don't miss it!", 'Integer value for the number of add-ons in the add-on list. (eg: 6)', 'timeline-express' ), count( $addon_array ) ),
+	'description'   => sprintf(
+		 /* translator: %s: Integer value for the number of add-ons in the add-on list. (eg: 6). */
+		esc_html__( "Get any and all %s of the Timeline Express add-ons, for one low price! Select a 5 or 10 site license, and receive all current and future add-ons for Timeline Express along with updates and priority product support. An amazing deal, don't miss it!", 'timeline-express' ),
+		count( $addon_array )
+	),
 	'purchase_url'  => 'https://www.wp-timelineexpress.com/products/timeline-express-bundle/',
 	'popular'       => true,
 ] );

--- a/lib/admin/pages/page.welcome.php
+++ b/lib/admin/pages/page.welcome.php
@@ -28,7 +28,13 @@ $selected = isset( $_GET['tab'] ) ? $_GET['tab'] : 'timeline-express-getting-sta
 			<img src="<?php echo esc_url( TIMELINE_EXPRESS_URL . 'lib/admin/images/timeline-express-logo-128.png' ); ?>" title="Timeline Express" />
 		</div>
 
-		<h1><?php printf( esc_html_x( 'Welcome to Timeline Express v%s', 'Integer value, representing the plugin version number.', 'timeline-express' ), esc_html( TIMELINE_EXPRESS_VERSION_CURRENT ) ); ?></h1>
+		<h1><?php
+			printf(
+				/* translator: %s: Integer value, representing the plugin version number. */
+				esc_html__( 'Welcome to Timeline Express v%s', 'timeline-express' ),
+				esc_html( TIMELINE_EXPRESS_VERSION_CURRENT )
+			);
+		?></h1>
 
 		<div class="about-text">
 			<?php esc_html_e( "Thank you for choosing Timeline Express - the most beginner friendly, attractive and powerful WordPress Timeline plugin. Here's how to get started.", 'timeline-express' ); ?>
@@ -71,9 +77,21 @@ $selected = isset( $_GET['tab'] ) ? $_GET['tab'] : 'timeline-express-getting-sta
 
 				<div class="feature-section-content">
 
-					<p><?php printf( esc_html_x( 'Timeline Express makes it easy to create and display a beautiful and animated timeline in WordPress. Feel free to read our support article, %s.', 'Anchor tag linking back to the Timeline Express documentation.', 'timeline-express' ), '<a href="https://www.wp-timelineexpress.com/documentation/creating-an-announcement/" target="_blank">How To Create Your First Announcement</a>' ); ?>
+					<p><?php
+						printf(
+							/* translator: %s: Anchor tag linking back to the Timeline Express documentation. */
+							esc_html__( 'Timeline Express makes it easy to create and display a beautiful and animated timeline in WordPress. Feel free to read our support article, %s.', 'timeline-express' ),
+							'<a href="https://www.wp-timelineexpress.com/documentation/creating-an-announcement/" target="_blank">' . esc_html__( 'How To Create Your First Announcement', 'timeine-express-pro' ) . '</a>'
+						);
+					?></p>
 
-					<p><?php printf( esc_html_x( 'The process is so intuitive that you can jump right in by going to %s.', 'Anchor tag linking to create a new announcement.', 'timeline-express' ), '<a href="' . esc_url( admin_url( 'post-new.php?post_type=te_announcements' ) ) . '">' . esc_html__( 'Timeline Express &#8594; New Announcement', 'timeine-express-pro' ) . '</a>' ); ?>
+					<p><?php
+						printf(
+							/* translator: %s: Anchor tag linking to create a new announcement. */
+							esc_html__( 'The process is so intuitive that you can jump right in by going to %s.', 'timeline-express' ),
+							'<a href="' . esc_url( admin_url( 'post-new.php?post_type=te_announcements' ) ) . '">' . esc_html__( 'Timeline Express &#8594; New Announcement', 'timeine-express-pro' ) . '</a>'
+						);
+					?></p>
 
 					<h4><?php esc_html_e( 'Announcement Images', 'timeline-express' );?></h4>
 
@@ -97,9 +115,21 @@ $selected = isset( $_GET['tab'] ) ? $_GET['tab'] : 'timeline-express-getting-sta
 
 				<div class="feature-section-content">
 
-					<p><?php printf( esc_html_x( 'Head into the %s to tweak how the Timeline is going to function and display on your site. You can tweak the visual appearance of the timeline, and the order and time period from which announcements should disdplay.', 'Anchor tag linking back to the Timeline Express settings page.', 'timeline-express' ), '<a href="' . esc_url( admin_url( 'edit.php?post_type=te_announcements&page=timeline-express-settings' ) ) . '">' . esc_attr__( 'Settings Page', 'timeline-express' ) . '</a>' ); ?>
+					<p><?php
+						printf(
+							/* translator: %s: Anchor tag linking back to the Timeline Express settings page. */
+							esc_html__( 'Head into the %s to tweak how the Timeline is going to function and display on your site. You can tweak the visual appearance of the timeline, and the order and time period from which announcements should disdplay.', 'timeline-express' ),
+							'<a href="' . esc_url( admin_url( 'edit.php?post_type=te_announcements&page=timeline-express-settings' ) ) . '">' . esc_html__( 'Settings Page', 'timeline-express' ) . '</a>'
+						);
+					?></p>
 
-					<p><?php printf( esc_html_x( "%s: If you ever notice something doesn't look correct or function properly on the timeline, double check that your settings are correct.", 'HTML markup (strong tags) surrounding the words "Pro Tip"', 'timeline-express' ), '<strong>' . esc_html__( 'Pro Tip', 'timeline-express' ) . '</strong>' ); ?>
+					<p><?php
+						printf(
+							/* translator: %s: HTML markup (strong tags) surrounding the words "Pro Tip". */
+							esc_html__( "%s: If you ever notice something doesn't look correct or function properly on the timeline, double check that your settings are correct.", 'timeline-express' ),
+							'<strong>' . esc_html__( 'Pro Tip', 'timeline-express' ) . '</strong>'
+						);
+					?></p>
 
 				</div>
 

--- a/lib/admin/pages/page.welcome.php
+++ b/lib/admin/pages/page.welcome.php
@@ -30,7 +30,7 @@ $selected = isset( $_GET['tab'] ) ? $_GET['tab'] : 'timeline-express-getting-sta
 
 		<h1><?php
 			printf(
-				/* translator: %s: Integer value, representing the plugin version number. */
+				/* translators: %s: Integer value, representing the plugin version number. */
 				esc_html__( 'Welcome to Timeline Express v%s', 'timeline-express' ),
 				esc_html( TIMELINE_EXPRESS_VERSION_CURRENT )
 			);
@@ -79,7 +79,7 @@ $selected = isset( $_GET['tab'] ) ? $_GET['tab'] : 'timeline-express-getting-sta
 
 					<p><?php
 						printf(
-							/* translator: %s: Anchor tag linking back to the Timeline Express documentation. */
+							/* translators: %s: Anchor tag linking back to the Timeline Express documentation. */
 							esc_html__( 'Timeline Express makes it easy to create and display a beautiful and animated timeline in WordPress. Feel free to read our support article, %s.', 'timeline-express' ),
 							'<a href="https://www.wp-timelineexpress.com/documentation/creating-an-announcement/" target="_blank">' . esc_html__( 'How To Create Your First Announcement', 'timeine-express-pro' ) . '</a>'
 						);
@@ -87,7 +87,7 @@ $selected = isset( $_GET['tab'] ) ? $_GET['tab'] : 'timeline-express-getting-sta
 
 					<p><?php
 						printf(
-							/* translator: %s: Anchor tag linking to create a new announcement. */
+							/* translators: %s: Anchor tag linking to create a new announcement. */
 							esc_html__( 'The process is so intuitive that you can jump right in by going to %s.', 'timeline-express' ),
 							'<a href="' . esc_url( admin_url( 'post-new.php?post_type=te_announcements' ) ) . '">' . esc_html__( 'Timeline Express &#8594; New Announcement', 'timeine-express-pro' ) . '</a>'
 						);
@@ -117,7 +117,7 @@ $selected = isset( $_GET['tab'] ) ? $_GET['tab'] : 'timeline-express-getting-sta
 
 					<p><?php
 						printf(
-							/* translator: %s: Anchor tag linking back to the Timeline Express settings page. */
+							/* translators: %s: Anchor tag linking back to the Timeline Express settings page. */
 							esc_html__( 'Head into the %s to tweak how the Timeline is going to function and display on your site. You can tweak the visual appearance of the timeline, and the order and time period from which announcements should disdplay.', 'timeline-express' ),
 							'<a href="' . esc_url( admin_url( 'edit.php?post_type=te_announcements&page=timeline-express-settings' ) ) . '">' . esc_html__( 'Settings Page', 'timeline-express' ) . '</a>'
 						);
@@ -125,7 +125,7 @@ $selected = isset( $_GET['tab'] ) ? $_GET['tab'] : 'timeline-express-getting-sta
 
 					<p><?php
 						printf(
-							/* translator: %s: HTML markup (strong tags) surrounding the words "Pro Tip". */
+							/* translators: %s: HTML markup (strong tags) surrounding the words "Pro Tip". */
 							esc_html__( "%s: If you ever notice something doesn't look correct or function properly on the timeline, double check that your settings are correct.", 'timeline-express' ),
 							'<strong>' . esc_html__( 'Pro Tip', 'timeline-express' ) . '</strong>'
 						);


### PR DESCRIPTION
You should never use context `_x()` function to describe placeholders. You should use only translator comments `/* translators: %s: placeholder description */`. The translator comment will appear on the sidebar:

![context](https://cloud.githubusercontent.com/assets/576623/16934563/133ade84-4d60-11e6-86d3-a71508640ea8.png)

As for the `_x()`, in WordPress core, we use context functions when a string is used in many places, but we want one of those strings to have a different meaning. When we add the context function, this string will appear as a separate string in translate.wordpress.org.

![context](https://cloud.githubusercontent.com/assets/576623/17271524/14ae0aa4-5687-11e6-9e81-8cfcc2f125fd.png)

When using context function, It creates a new line in translate.wordpress.org, and allows you to provide a different meaning for this particular string.
