### PR TITLE
1.5.2

### DIFF
--- a/lib/classes/class-timeline-express-admin.php
+++ b/lib/classes/class-timeline-express-admin.php
@@ -478,10 +478,10 @@ class Timeline_Express_Admin {
 		 * @var array
 		 */
 		return (array) apply_filters(
-			'timeline_express_popups_addon_announcement_image', [
+			'timeline_express_popups_addon_announcement_image', array(
 				'iframe' => false,
 				'url'    => $image_url ? esc_url( $image_url ) : false,
-			], $image_id
+			), $image_id
 		);
 
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -371,6 +371,9 @@ The above example will load font awesome version 4.4.0 instead of the current st
 
 == Changelog ==
 
+= 1.5.2 - August, 2017 =
+- Tweak: Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
+
 = 1.5.1 - July, 2017 =
 - Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
 - Tweak: Updated regex when generating icons. Props @tkchouaki
@@ -788,6 +791,5 @@ The above example will load font awesome version 4.4.0 instead of the current st
 
 == Upgrade Notice ==
 
-= 1.5.1 - July, 2017 =
-- Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
-- Tweak: Updated regex when generating icons. Props @tkchouaki
+= 1.5.2 - August, 2017 =
+- Tweak: Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.

--- a/readme.txt
+++ b/readme.txt
@@ -372,7 +372,7 @@ The above example will load font awesome version 4.4.0 instead of the current st
 == Changelog ==
 
 = 1.5.2 - August, 2017 =
-- Tweak: Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
+- Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
 
 = 1.5.1 - July, 2017 =
 - Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
@@ -792,4 +792,4 @@ The above example will load font awesome version 4.4.0 instead of the current st
 == Upgrade Notice ==
 
 = 1.5.2 - August, 2017 =
-- Tweak: Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
+- Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.


### PR DESCRIPTION
#### 1.5.2 - August, 2017
- Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
