### PR TITLE
1.5.2

### DIFF
--- a/lib/classes/class-timeline-express-compat.php
+++ b/lib/classes/class-timeline-express-compat.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Timeline Express :: Compatibility Class
+ *
+ * @author Code Parrots
+ * @link http://www.codeparrots.com
+ * @package Timeline_Express
+ * @since NEXT
+ */
+
+class Timeline_Express_Compat {
+
+	public function __construct() {
+
+		add_action( 'init', array( $this, 'include_compat_files' ) );
+
+	}
+
+	/**
+	 * Include our compatibility files.
+	 *
+	 * @since NEXT
+	 */
+	public function include_compat_files() {
+
+		$whitelist = array(
+			'qtranslate.php',
+		);
+
+		foreach ( $whitelist as $compat_file ) {
+
+			if ( ! is_readable( TIMELINE_EXPRESS_PATH . "lib/compat/{$compat_file}" ) ) {
+
+				continue;
+
+			}
+
+			include_once TIMELINE_EXPRESS_PATH . "lib/compat/{$compat_file}";
+
+		}
+
+	}
+
+}
+
+$timeline_express_compat = new Timeline_Express_Compat();

--- a/lib/classes/class-timeline-express.php
+++ b/lib/classes/class-timeline-express.php
@@ -31,6 +31,9 @@ class TimelineExpressBase {
 		/* Include Public Class file */
 		include_once TIMELINE_EXPRESS_PATH . 'lib/classes/class-timeline-express-public.php';
 
+		/* Include Compatibility Class file */
+		include_once TIMELINE_EXPRESS_PATH . 'lib/classes/class-timeline-express-compat.php';
+
 		/* Register our custom timeline express image size (350px x 120px) */
 		add_image_size( 'timeline-express', '350', '120', true );
 
@@ -121,35 +124,21 @@ class TimelineExpressBase {
 		$timeline_express_options = timeline_express_get_options();
 
 		/* Update our options */
-		$timeline_express_options['announcement-time-frame'] = sanitize_text_field( $options['announcement-time-frame'] );
-
-		$timeline_express_options['announcement-display-order'] = sanitize_text_field( $options['announcement-display-order'] );
-
-		$timeline_express_options['excerpt-trim-length'] = (int) sanitize_text_field( $options['excerpt-trim-length'] );
-
-		$timeline_express_options['excerpt-random-length'] = (int) ( isset( $options['excerpt-random-length'] ) ) ? 1 : 0;
-
-		$timeline_express_options['date-visibility'] = sanitize_text_field( $options['date-visibility'] );
-
-		$timeline_express_options['read-more-visibility'] = sanitize_text_field( $options['read-more-visibility'] );
-
-		$timeline_express_options['default-announcement-icon'] = sanitize_text_field( $options['default-announcement-icon'] );
-
-		$timeline_express_options['default-announcement-color'] = sanitize_text_field( $options['default-announcement-color'] );
-
-		$timeline_express_options['announcement-bg-color'] = sanitize_text_field( $options['announcement-bg-color'] );
-
-		$timeline_express_options['announcement-box-shadow-color'] = sanitize_text_field( $options['announcement-box-shadow-color'] );
-
-		$timeline_express_options['announcement-background-line-color'] = sanitize_text_field( $options['announcement-background-line-color'] );
-
-		$timeline_express_options['no-events-message'] = sanitize_text_field( $options['no-events-message'] );
-
-		$timeline_express_options['announcement-appear-in-searches'] = sanitize_text_field( $options['announcement-appear-in-searches'] );
-
+		$timeline_express_options['announcement-time-frame']                     = sanitize_text_field( $options['announcement-time-frame'] );
+		$timeline_express_options['announcement-display-order']                  = sanitize_text_field( $options['announcement-display-order'] );
+		$timeline_express_options['excerpt-trim-length']                         = (int) sanitize_text_field( $options['excerpt-trim-length'] );
+		$timeline_express_options['excerpt-random-length']                       = (int) ( isset( $options['excerpt-random-length'] ) ) ? 1 : 0;
+		$timeline_express_options['date-visibility']                             = sanitize_text_field( $options['date-visibility'] );
+		$timeline_express_options['read-more-visibility']                        = sanitize_text_field( $options['read-more-visibility'] );
+		$timeline_express_options['default-announcement-icon']                   = sanitize_text_field( $options['default-announcement-icon'] );
+		$timeline_express_options['default-announcement-color']                  = sanitize_text_field( $options['default-announcement-color'] );
+		$timeline_express_options['announcement-bg-color']                       = sanitize_text_field( $options['announcement-bg-color'] );
+		$timeline_express_options['announcement-box-shadow-color']               = sanitize_text_field( $options['announcement-box-shadow-color'] );
+		$timeline_express_options['announcement-background-line-color']          = sanitize_text_field( $options['announcement-background-line-color'] );
+		$timeline_express_options['no-events-message']                           = sanitize_text_field( $options['no-events-message'] );
+		$timeline_express_options['announcement-appear-in-searches']             = sanitize_text_field( $options['announcement-appear-in-searches'] );
 		$timeline_express_options['delete-announcement-posts-on-uninstallation'] = (int) ( isset( $options['delete-announcement-posts-on-uninstallation'] ) ) ? 1 : 0;
-
-		$timeline_express_options['disable-animation'] = (int) ( isset( $options['disable-animation'] ) ) ? 1 : 0;
+		$timeline_express_options['disable-animation']                           = (int) ( isset( $options['disable-animation'] ) ) ? 1 : 0;
 
 		/* Delete the transient, to refresh the frontend timeline (display order, excerpt length etc.) */
 		delete_timeline_express_transients();

--- a/lib/compat/qtranslate.php
+++ b/lib/compat/qtranslate.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Q-translate compatibility.
+ * @source https://wordpress.org/plugins/qtranslate-x/
+ * @reference https://wordpress.org/support/topic/multilang-issue/
+ *
+ * @since NEXT
+ */
+
+/**
+ * Clear Timeline Express cache on qtranslate pages.
+ * Delete the cache when qtranslate is used to translate Timeline Express.
+ *
+ * @since NEXT
+ */
+function timeline_express_qtranslate_bust_cache() {
+
+	global $post;
+
+	if ( ! isset( $post->ID ) || false === get_transient( "timeline-express-query-{$post->ID}" ) ) {
+
+		return;
+
+	}
+
+	delete_transient( "timeline-express-query-{$post->ID}" );
+
+}
+add_action( 'qtranslate_head_add_css', 'timeline_express_qtranslate_bust_cache' );

--- a/readme.txt
+++ b/readme.txt
@@ -372,6 +372,7 @@ The above example will load font awesome version 4.4.0 instead of the current st
 == Changelog ==
 
 = 1.5.2 - August, 2017 =
+- New: Introduced <a href="https://wordpress.org/plugins/qtranslate-x/">qtranslate-x</a> compatibility files. Timeline Express cache is cleared when using qtranslate, to ensure translations load properly.
 - Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
 
 = 1.5.1 - July, 2017 =
@@ -792,4 +793,5 @@ The above example will load font awesome version 4.4.0 instead of the current st
 == Upgrade Notice ==
 
 = 1.5.2 - August, 2017 =
+- New: Introduced <a href="https://wordpress.org/plugins/qtranslate-x/">qtranslate-x</a> compatibility files. Timeline Express cache is cleared when using qtranslate, to ensure translations load properly.
 - Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.


### PR DESCRIPTION
#### 1.5.2 - August, 2017
- New: Introduced <a href="https://wordpress.org/plugins/qtranslate-x/">qtranslate-x</a> compatibility files. Timeline Express cache is cleared when using qtranslate, to ensure translations load properly.
- Tweak: Remove shorthand array syntax [] to maintain backwards compatibility with PHP < 5.6.
