### PR TITLE
Update Single Template

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/admin/CMB2"]
 	path = lib/admin/CMB2
 	url = https://github.com/CMB2/CMB2.git
+	branch = trunk

--- a/lib/admin/metaboxes/metaboxes.announcements.php
+++ b/lib/admin/metaboxes/metaboxes.announcements.php
@@ -88,6 +88,9 @@ $announcement_metabox->add_field(
 		'desc' => sprintf( esc_html( 'Select a banner image for this %s (optional). (recommended 650px wide or larger)', 'timeline-express' ), strtolower( $timeline_express_singular_name ) ),
 		'id'   => $prefix . 'image',
 		'type' => 'file',
+		'options' => array(
+			'url' => false, // Hide the text input for the url
+		),
 	)
 );
 

--- a/lib/classes/class-timeline-express-public.php
+++ b/lib/classes/class-timeline-express-public.php
@@ -106,9 +106,6 @@ class Timeline_Express_Public {
 			// Announcement Featured Image.
 			add_filter( 'get_post_metadata', array( $this, 'timeline_express_filter_featured_image' ), 10, 4 );
 
-			// Announcement Video Featured Image.
-			add_filter( 'post_thumbnail_html', array( $this, 'timeline_express_filter_featured_image_video' ), 10, 5 );
-
 			// Announcement Categories.
 			add_filter( 'the_category_list', array( $this, 'timeline_express_filter_categories' ), 10, 2 );
 
@@ -183,39 +180,6 @@ class Timeline_Express_Public {
 		}
 
 		return (int) get_post_meta( $post_id, 'announcement_image_id', true );
-
-	}
-
-	/**
-	 * Display the YouTube/Vimeo video in the featured image location.
-	 *
-	 * @param string       $html              The post thumbnail HTML.
-	 * @param int          $post_id           The post ID.
-	 * @param string       $post_thumbnail_id The post thumbnail ID.
-	 * @param string|array $size              The post thumbnail size. Image size or array of width and height
-	 *                                        values (in that order). Default 'post-thumbnail'.
-	 * @param string       $attr              Query string of attributes.
-	 *
-	 * @return mixed Markup for the video featured image.
-	 */
-	function timeline_express_filter_featured_image_video( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
-
-		/**
-		 * PHP_INT_MAX === non-image featured image
-		 * eg: YouTube/Vimeo URL
-		 */
-		if ( PHP_INT_MAX !== $post_thumbnail_id ) {
-
-			return $html;
-
-		}
-
-		ob_start();
-		timeline_express_get_announcement_image( $post_id );
-		$image = ob_get_contents();
-		ob_get_clean();
-
-		return $image;
 
 	}
 

--- a/lib/classes/class-timeline-express-public.php
+++ b/lib/classes/class-timeline-express-public.php
@@ -56,10 +56,8 @@ class Timeline_Express_Public {
 
 	/**
 	 * Decide what template file to use to display single announcements.
-	 * Note: First checks for a directory in the theme root /timeline-express/single-te_announcements.php,
-	 *       Next it checks for a single.php template in the theme root
-	 *       Next it checksf or a page.php template in the theme root
-	 *       If all else fails, it will use the default template defined by WordPress.
+	 *  1. First checks for a directory in the theme root /timeline-express/single-te_announcements.php,
+	 *  2. Else it will use the default single post template.
 	 *
 	 * @param  string   $page_template    The page template name to be used for single announcements.
 	 * @return string                     The page template to be used for the single announcements.
@@ -76,14 +74,43 @@ class Timeline_Express_Public {
 
 		}
 
+		// Legacy support for old the old template.
+		if ( defined( 'TIMELINE_EXPRESS_LEGACY_SINGLE_TEMPLATE' ) && TIMELINE_EXPRESS_LEGACY_SINGLE_TEMPLATE ) {
+
+			$single_template = TIMELINE_EXPRESS_PATH . 'lib/public/partials/single-timeline-express.php';
+
+		}
+
 		/* If custom template file exists */
 		if ( file_exists( get_stylesheet_directory() . '/timeline-express/single-timeline-express.php' ) ) {
 
 			$single_template = get_stylesheet_directory() . '/timeline-express/single-timeline-express.php';
 
-		} else {
+			if ( ! defined( 'TIMELINE_EXPRESS_LEGACY_SINGLE_TEMPLATE' ) ) {
 
-			$single_template = TIMELINE_EXPRESS_PATH . 'lib/public/partials/single-timeline-express.php';
+				define( 'TIMELINE_EXPRESS_LEGACY_SINGLE_TEMPLATE', true );
+
+			} // @codingStandardsIgnoreLine
+
+		}
+
+		if ( ! defined( 'TIMELINE_EXPRESS_LEGACY_SINGLE_TEMPLATE' ) || ( defined( 'TIMELINE_EXPRESS_LEGACY_SINGLE_TEMPLATE' ) && ! TIMELINE_EXPRESS_LEGACY_SINGLE_TEMPLATE ) ) {
+
+			// Announcement Date.
+			add_filter( 'the_date', array( $this, 'timeline_express_filter_single_post_date' ), 10, 4 );
+
+			// Filter the modified dates - for themes.
+			add_filter( 'get_the_modified_date', array( $this, 'timeline_express_filter_single_modified_date' ), 10, 3 );
+			add_filter( 'get_the_date', array( $this, 'timeline_express_filter_single_modified_date' ), 10, 3 );
+
+			// Announcement Featured Image.
+			add_filter( 'get_post_metadata', array( $this, 'timeline_express_filter_featured_image' ), 10, 4 );
+
+			// Announcement Video Featured Image.
+			add_filter( 'post_thumbnail_html', array( $this, 'timeline_express_filter_featured_image_video' ), 10, 5 );
+
+			// Announcement Categories.
+			add_filter( 'the_category_list', array( $this, 'timeline_express_filter_categories' ), 10, 2 );
 
 		}
 
@@ -92,6 +119,122 @@ class Timeline_Express_Public {
 		 * Legacy Support, 2 filters
 		 */
 		return apply_filters( 'timeline_express_single_page_template', apply_filters( 'timeline-express-single-page-template', $single_template ) );
+
+	}
+
+	/**
+	 * Filter the sigle timeline express post date.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string $the_date The formatted date string.
+	 * @param string $d        PHP date format. Defaults to 'date_format' option
+	 *                         if not specified.
+	 * @param string $before   HTML output before the date.
+	 * @param string $after    HTML output after the date.
+	 *
+	 * @return string Timeline Express announcement date.
+	 */
+	public function timeline_express_filter_single_post_date( $the_date, $d, $before, $after ) {
+
+		global $post;
+
+		return timeline_express_get_announcement_date( $post->ID );
+
+	}
+
+	/**
+	 * Filter the sigle timeline express modified date.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param string|bool  $the_time The formatted date or false if no post is found.
+	 * @param string       $d        PHP date format. Defaults to value specified in
+	 *                               'date_format' option.
+	 * @param WP_Post|null $post     WP_Post object or null if no post is found.
+	 *
+	 * @return string Timeline Express announcement date.
+	 */
+	public function timeline_express_filter_single_modified_date( $the_time, $d, $post ) {
+
+		return timeline_express_get_announcement_date( $post->ID );
+
+	}
+
+	/**
+	 * Filters the post thumbnail HTML.
+	 *
+	 * @since 2.0.5
+	 *
+	 * @param null|array|string $value    The value get_metadata() should return a single metadata value, or an
+	 *                                    array of values.
+	 * @param int               $post_id  Post ID.
+	 * @param string            $meta_key Meta key.
+	 * @param string|array      $single   Meta value, or an array of values.
+	 * @return array|null|string The attachment metadata value, array of values, or null.
+	 */
+	public function timeline_express_filter_featured_image( $value, $post_id, $meta_key, $single ) {
+
+		// Only filter if we're not recursing and if it is a post thumbnail ID
+		if ( '_thumbnail_id' !== $meta_key ) {
+
+			return $value;
+
+		}
+
+		return (int) get_post_meta( $post_id, 'announcement_image_id', true );
+
+	}
+
+	/**
+	 * Display the YouTube/Vimeo video in the featured image location.
+	 *
+	 * @param string       $html              The post thumbnail HTML.
+	 * @param int          $post_id           The post ID.
+	 * @param string       $post_thumbnail_id The post thumbnail ID.
+	 * @param string|array $size              The post thumbnail size. Image size or array of width and height
+	 *                                        values (in that order). Default 'post-thumbnail'.
+	 * @param string       $attr              Query string of attributes.
+	 *
+	 * @return mixed Markup for the video featured image.
+	 */
+	function timeline_express_filter_featured_image_video( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
+
+		/**
+		 * PHP_INT_MAX === non-image featured image
+		 * eg: YouTube/Vimeo URL
+		 */
+		if ( PHP_INT_MAX !== $post_thumbnail_id ) {
+
+			return $html;
+
+		}
+
+		ob_start();
+		timeline_express_get_announcement_image( $post_id );
+		$image = ob_get_contents();
+		ob_get_clean();
+
+		return $image;
+
+	}
+
+
+	/**
+	 * Filter the Timeline Express announcement categories.
+	 * Resource: https://github.com/WordPress/WordPress/blob/39c7daf7db151eee6375974aceb8520fa85a822d/wp-includes/category-template.php#L148
+	 *
+	 * @filter the_category_list
+	 *
+	 * @param array    $categories An array of the post's categories.
+	 * @param int|bool $post_id    ID of the post we're retrieving categories for. When `false`, we assume the
+	 *                             current post in the loop.
+	 *
+	 * @return array Array of announcement categories.
+	 */
+	public function timeline_express_filter_categories( $categories, $post_id ) {
+
+		return timeline_express_tax_array( 'categories', 'all' );
 
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -371,6 +371,10 @@ The above example will load font awesome version 4.4.0 instead of the current st
 
 == Changelog ==
 
+= 1.5.4 - January, 2018 =
+- Tweak: Single templates now inherit the active theme, to prevent strange templates when a theme does not support the single timeline layout. Users can define `TIMELINE_EXPRESS_LEGACY_SINGLE_TEMPLATE` constant to enable legacy templates. eg: `define( 'TIMELINE_EXPRESS_LEGACY_SINGLE_TEMPLATE', true );`.
+- Tweak: Removed the URL field for announcement banners - caused confusion believing that external images and YouTube/Vimeo videos could be used. (this is a pro feature)
+
 = 1.5.3 - November, 2017 =
 - New: Updated translation files.
 


### PR DESCRIPTION
- Update the single template. Now inherits the active theme instead of attempting to create its own.
- Removed the URL field from the announcement banner field.
- Set `CMB2` submodule to track `trunk` branch.